### PR TITLE
Fix: River create view

### DIFF
--- a/views/default/river/object/thewire/create.php
+++ b/views/default/river/object/thewire/create.php
@@ -1,36 +1,39 @@
-<?php
-$item = elgg_extract('item', $vars);
-
-$object = $item->getObjectEntity();
+$object = $vars["item"]->getObjectEntity();
 $excerpt = strip_tags($object->description);
-$excerpt = thewire_tools_filter($excerpt);
 
-$subject = $item->getSubjectEntity();
-$subject_link = elgg_view('output/url', [
-	'href' => $subject->getURL(),
-	'text' => $subject->name,
-	'class' => 'elgg-river-subject',
-	'is_trusted' => true,
-]);
-
-$object_link = elgg_view('output/url', [
-	'href' => "thewire/owner/$subject->username",
-	'text' => elgg_echo('thewire:wire'),
-	'class' => 'elgg-river-object',
-	'is_trusted' => true,
-]);
-
-$summary = elgg_echo('river:create:object:thewire', [$subject_link, $object_link]);
-
-$attachments = '';
-$reshare = $object->getEntitiesFromRelationship(['relationship' => 'reshare', 'limit' => 1]);
+$attachments = "";
+$reshare = $object->getEntitiesFromRelationship(array("relationship" => "reshare", "limit" => 1));
 if (!empty($reshare)) {
-	$attachments = elgg_view('thewire_tools/reshare_source', ['entity' => $reshare[0]]);
+    $attachments = elgg_view("thewire_tools/reshare_source", array("entity" => $reshare[0]));
 }
 
-echo elgg_view('river/elements/layout', [
-	'item' => $item,
-	'message' => $excerpt,
-	'summary' => $summary,
-	'attachments' => $attachments,
-]);
+if($attachments==""){
+$excerpt = elgg_preview($excerpt);
+$excerpt = thewire_filter($excerpt);
+}else{
+$excerpt = thewire_tools_filter($excerpt);
+}
+
+$subject = $vars["item"]->getSubjectEntity();
+$subject_link = elgg_view("output/url", array(
+    "href" => $subject->getURL(),
+    "text" => $subject->name,
+    "class" => "elgg-river-subject",
+    "is_trusted" => true,
+));
+
+$object_link = elgg_view("output/url", array(
+    "href" => "thewire/owner/$subject->username",
+    "text" => elgg_echo("thewire:wire"),
+    "class" => "elgg-river-object",
+    "is_trusted" => true,
+));
+
+$summary = elgg_echo("river:create:object:thewire", array($subject_link, $object_link));
+
+echo elgg_view("river/elements/layout", array(
+    "item" => $vars["item"],
+    "message" => $excerpt,
+    "summary" => $summary,
+    "attachments" => $attachments
+));

--- a/views/default/river/object/thewire/create.php
+++ b/views/default/river/object/thewire/create.php
@@ -1,6 +1,3 @@
-
-text/x-generic create.php ( PHP script text )
-
 <?php
 /**
  * File river view.

--- a/views/default/river/object/thewire/create.php
+++ b/views/default/river/object/thewire/create.php
@@ -1,39 +1,68 @@
+
+text/x-generic create.php ( PHP script text )
+
+<?php
+/**
+ * File river view.
+ */
+
 $object = $vars["item"]->getObjectEntity();
 $excerpt = strip_tags($object->description);
 
 $attachments = "";
-$reshare = $object->getEntitiesFromRelationship(array("relationship" => "reshare", "limit" => 1));
-if (!empty($reshare)) {
-    $attachments = elgg_view("thewire_tools/reshare_source", array("entity" => $reshare[0]));
+
+if(elgg_is_active_plugin("thewire_tools") && elgg_is_active_plugin("elgg-thewire-links-preview")){
+	$reshare = $object->getEntitiesFromRelationship(array("relationship" => "reshare", "limit" => 1));
+	if (!empty($reshare)) {
+		$attachments = elgg_view("thewire_tools/reshare_source", array("entity" => $reshare[0]));
+	}
+
+	if($attachments==""){
+	$excerpt = elgg_preview($excerpt);
+	$excerpt = thewire_filter($excerpt);
+	}else{
+	$excerpt = thewire_tools_filter($excerpt);
+	}
 }
 
-if($attachments==""){
-$excerpt = elgg_preview($excerpt);
-$excerpt = thewire_filter($excerpt);
-}else{
-$excerpt = thewire_tools_filter($excerpt);
+if(elgg_is_active_plugin("thewire_tools") && !elgg_is_active_plugin("elgg-thewire-links-preview")){
+	$attachments = "";
+	$reshare = $object->getEntitiesFromRelationship(array("relationship" => "reshare", "limit" => 1));
+	if (!empty($reshare)) {
+		$attachments = elgg_view("thewire_tools/reshare_source", array("entity" => $reshare[0]));
+	}
+	$excerpt = thewire_tools_filter($excerpt);
+}
+
+if(elgg_is_active_plugin("elgg-thewire-links-preview") && !elgg_is_active_plugin("thewire_tools")){
+	$excerpt = elgg_preview($excerpt);
+	$excerpt = thewire_filter($excerpt);	
+}
+
+if(!elgg_is_active_plugin("elgg-thewire-links-preview") && !elgg_is_active_plugin("thewire_tools")){
+	$excerpt = thewire_filter($excerpt);	
 }
 
 $subject = $vars["item"]->getSubjectEntity();
 $subject_link = elgg_view("output/url", array(
-    "href" => $subject->getURL(),
-    "text" => $subject->name,
-    "class" => "elgg-river-subject",
-    "is_trusted" => true,
+	"href" => $subject->getURL(),
+	"text" => $subject->name,
+	"class" => "elgg-river-subject",
+	"is_trusted" => true,
 ));
 
 $object_link = elgg_view("output/url", array(
-    "href" => "thewire/owner/$subject->username",
-    "text" => elgg_echo("thewire:wire"),
-    "class" => "elgg-river-object",
-    "is_trusted" => true,
+	"href" => "thewire/owner/$subject->username",
+	"text" => elgg_echo("thewire:wire"),
+	"class" => "elgg-river-object",
+	"is_trusted" => true,
 ));
 
 $summary = elgg_echo("river:create:object:thewire", array($subject_link, $object_link));
 
 echo elgg_view("river/elements/layout", array(
-    "item" => $vars["item"],
-    "message" => $excerpt,
-    "summary" => $summary,
-    "attachments" => $attachments
+	"item" => $vars["item"],
+	"message" => $excerpt,
+	"summary" => $summary,
+	"attachments" => $attachments
 ));


### PR DESCRIPTION
There is a conflict between TheWire Links Preview Advanced and TheWire Tools plugin.

 Both the plugin has a common file: mod/< plugin_name >\views\default\river\object< plugin_name >\create.php

Now as I place the plugin one after the other, the create file of the later plugin from the list is being used to generate the preview and the above plugins is ignored.
